### PR TITLE
Re-export the StatusCode as it's used in a return type

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -5,13 +5,14 @@ use hyper::error::Error;
 use hyper::net::HttpsConnector;
 use hyper::header::{Authorization, Bearer, ContentType, Headers, UserAgent};
 use hyper::mime::{Mime, TopLevel, SubLevel};
-use hyper::status::StatusCode;
 
 use hyper_native_tls::NativeTlsClient;
 
 use data_encoding::base64;
 
 use serde_json;
+
+pub use hyper::status::StatusCode;
 
 const V3_API_URL: &'static str = "https://api.sendgrid.com/v3/mail/send";
 


### PR DESCRIPTION
StatusCode is used as part of a return type. It's common to re-export the type in this case.

Hyper has also been updated to 0.11... but that change is a lot more than I'm wanting to handle just yet. :D.