### PR TITLE
add an add_bcc() function to allow bcc use

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -246,6 +246,20 @@ impl Personalization {
             }
         }
     }
+
+    // Add a BCC field
+    pub fn add_bcc(&mut self, bcc: Email) {
+        match self.bcc {
+            None => {
+                let mut bccs = Vec::new();
+                bccs.push(bcc);
+                self.bcc = Some(bccs);
+            }
+            Some(ref mut b) => {
+                b.push(bcc);
+            }
+        }
+    }
 }
 
 impl Attachment {

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -247,7 +247,7 @@ impl Personalization {
         }
     }
 
-    // Add a BCC field
+    /// Add a BCC field.
     pub fn add_bcc(&mut self, bcc: Email) {
         match self.bcc {
             None => {


### PR DESCRIPTION
There's a bcc field on the Personalization struct already, but no methods to access it. So this pr adds a method to add bccs to the personalization.