### PR TITLE
New return type for V3 mail send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sendgrid"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Garrett Squire <garrettsquire@gmail.com>"]
 description = "An unofficial client library for the SendGrid API"
 repository = "https://github.com/gsquire/sendgrid-rs"
@@ -17,4 +17,4 @@ reqwest = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-url = "1.6"
+url = "1.7"

--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -82,12 +82,18 @@ impl SGClient {
     pub fn send(self, mail_info: Mail) -> SendgridResult<String> {
         let client = Client::new();
         let mut headers = Headers::new();
-        headers.set(Authorization(Bearer { token: self.api_key.to_owned() }));
+        headers.set(Authorization(Bearer {
+            token: self.api_key.to_owned(),
+        }));
         headers.set(ContentType::form_url_encoded());
         headers.set(UserAgent::new("sendgrid-rs"));
 
         let post_body = make_post_body(mail_info)?;
-        let mut res = client.post(API_URL).headers(headers).body(post_body).send()?;
+        let mut res = client
+            .post(API_URL)
+            .headers(headers)
+            .body(post_body)
+            .send()?;
         let mut body = String::new();
         res.read_to_string(&mut body)?;
         Ok(body)

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -28,7 +28,7 @@ pub struct SGMailV3 {
     content: Vec<Content>,
     personalizations: Vec<Personalization>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<Attachment>>,
 }
 
@@ -37,7 +37,7 @@ pub struct SGMailV3 {
 pub struct Email {
     email: String,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
 }
 
@@ -55,25 +55,25 @@ pub struct Content {
 pub struct Personalization {
     to: Vec<Email>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     cc: Option<Vec<Email>>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     bcc: Option<Vec<Email>>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     subject: Option<String>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     headers: Option<SGMap>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     substitutions: Option<SGMap>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     custom_args: Option<SGMap>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     send_at: Option<u64>,
 }
 
@@ -86,22 +86,14 @@ pub struct Attachment {
 
     filename: String,
 
-    #[serde(rename = "type", skip_serializing_if = "check_encode")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     mime_type: Option<String>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     disposition: Option<String>,
 
-    #[serde(skip_serializing_if = "check_encode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     content_id: Option<String>,
-}
-
-// Checks if a value in the V3 message should be added to the JSON or not.
-fn check_encode<T>(value: &Option<T>) -> bool {
-    match *value {
-        Some(_) => false,
-        None => true,
-    }
 }
 
 impl V3Sender {

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -3,11 +3,13 @@ use errors::SendgridResult;
 use std::collections::HashMap;
 
 use reqwest::header::{Authorization, Bearer, ContentType, Headers, UserAgent};
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 
 use data_encoding::BASE64;
 
 use serde_json;
+
+pub use reqwest::Response;
 
 const V3_API_URL: &'static str = "https://api.sendgrid.com/v3/mail/send";
 
@@ -103,7 +105,7 @@ impl V3Sender {
     }
 
     /// Send a V3 message and return the status code or an error from the request.
-    pub fn send(&self, mail: &SGMailV3) -> SendgridResult<StatusCode> {
+    pub fn send(&self, mail: &SGMailV3) -> SendgridResult<Response> {
         let client = Client::new();
         let mut headers = Headers::new();
         headers.set(Authorization(Bearer {
@@ -114,7 +116,7 @@ impl V3Sender {
 
         let body = mail.gen_json();
         let res = client.post(V3_API_URL).headers(headers).body(body).send()?;
-        Ok(res.status())
+        Ok(res)
     }
 }
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -2,8 +2,8 @@ use errors::SendgridResult;
 
 use std::collections::HashMap;
 
-use reqwest::{Client, StatusCode};
 use reqwest::header::{Authorization, Bearer, ContentType, Headers, UserAgent};
+use reqwest::{Client, StatusCode};
 
 use data_encoding::BASE64;
 
@@ -106,7 +106,9 @@ impl V3Sender {
     pub fn send(&self, mail: &SGMailV3) -> SendgridResult<StatusCode> {
         let client = Client::new();
         let mut headers = Headers::new();
-        headers.set(Authorization(Bearer { token: self.api_key.to_owned() }));
+        headers.set(Authorization(Bearer {
+            token: self.api_key.to_owned(),
+        }));
         headers.set(ContentType::json());
         headers.set(UserAgent::new("sendgrid-rs"));
 


### PR DESCRIPTION
This PR adjusts the function to check which fields to serialize as well as introduces the `reqwest::Response` type. This allows users to read the body or check headers as needed.

Fixes #23 