### PR TITLE
refactor mail

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -14,17 +14,17 @@ fn main() {
 
     let sg = SGClient::new(api_key);
 
-    let mut mail_info = Mail::new();
-    mail_info.add_to("you@example.com");
-    mail_info.add_from("some@some.com");
-    mail_info.add_subject("Rust is rad");
-    mail_info.add_html("<h1>Hello from SendGrid!</h1>");
-    mail_info.add_from_name("Test");
-    mail_info.add_header("x-cool", "indeed");
-
     let mut x_smtpapi = String::new();
     x_smtpapi.push_str(r#"{"unique_args":{"test":7}}"#);
-    mail_info.add_x_smtpapi(x_smtpapi);
+
+    let mail_info = Mail::new()
+        .add_to("you@example.com")
+        .add_from("some@some.com")
+        .add_subject("Rust is rad")
+        .add_html("<h1>Hello from SendGrid!</h1>")
+        .add_from_name("Test")
+        .add_header("x-cool", "indeed")
+        .add_x_smtpapi(x_smtpapi);
 
     match sg.send(mail_info) {
         Err(err) => println!("Error: {}", err),

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -23,8 +23,8 @@ fn main() {
         .add_subject("Rust is rad")
         .add_html("<h1>Hello from SendGrid!</h1>")
         .add_from_name("Test")
-        .add_header("x-cool", "indeed")
-        .add_x_smtpapi(x_smtpapi);
+        .add_header("x-cool".to_string(), "indeed")
+        .add_x_smtpapi(&x_smtpapi);
 
     match sg.send(mail_info) {
         Err(err) => println!("Error: {}", err),

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,7 @@
 extern crate sendgrid;
 
-use sendgrid::mail::Mail;
-use sendgrid::sg_client::SGClient;
+use sendgrid::Mail;
+use sendgrid::SGClient;
 
 fn main() {
     let mut env_vars = std::env::vars();

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,6 +1,6 @@
 extern crate sendgrid;
 
-use sendgrid::Mail;
+use sendgrid::{Destination, Mail};
 use sendgrid::SGClient;
 
 fn main() {
@@ -18,7 +18,10 @@ fn main() {
     x_smtpapi.push_str(r#"{"unique_args":{"test":7}}"#);
 
     let mail_info = Mail::new()
-        .add_to("you@example.com")
+        .add_to(Destination {
+            address:"you@example.com",
+            name: "you there",
+        })
         .add_from("some@some.com")
         .add_subject("Rust is rad")
         .add_html("<h1>Hello from SendGrid!</h1>")

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,7 @@
 extern crate sendgrid;
 
-use sendgrid::{Destination, Mail};
 use sendgrid::SGClient;
+use sendgrid::{Destination, Mail};
 
 fn main() {
     let mut env_vars = std::env::vars();
@@ -19,10 +19,9 @@ fn main() {
 
     let mail_info = Mail::new()
         .add_to(Destination {
-            address:"you@example.com",
+            address: "you@example.com",
             name: "you there",
-        })
-        .add_from("some@some.com")
+        }).add_from("some@some.com")
         .add_subject("Rust is rad")
         .add_html("<h1>Hello from SendGrid!</h1>")
         .add_from_name("Test")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,5 @@ mod mail;
 mod sg_client;
 pub mod v3;
 
-pub use mail::{Mail,Destination};
+pub use mail::{Destination, Mail};
 pub use sg_client::SGClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ extern crate serde_json;
 extern crate url;
 
 pub mod errors;
-pub mod mail;
-pub mod sg_client;
+mod mail;
+mod sg_client;
 pub mod v3;
+
+pub use mail::Mail;
+pub use sg_client::SGClient;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,6 @@ mod mail;
 mod sg_client;
 pub mod v3;
 
-pub use mail::Mail;
+pub use mail::{Mail,Destination};
 pub use sg_client::SGClient;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,3 @@ pub mod v3;
 
 pub use mail::{Mail,Destination};
 pub use sg_client::SGClient;
-

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use serde_json;
 
 macro_rules! add_field {
-    // Create a setter that appends
+    // Create a setter that appends.
     ($method:ident << $field:ident: $ty:ty) => {
         pub fn $method(mut self, data: $ty) -> Mail<'a> {
             self.$field.push(data);
@@ -16,7 +16,7 @@ macro_rules! add_field {
         }
     };
 
-    // Create a setter that stores
+    // Create a setter that stores.
     ($method:ident = $field:ident: $ty:ty) => {
         pub fn $method(mut self, data: $ty) -> Mail<'a> {
             self.$field = data;
@@ -24,7 +24,7 @@ macro_rules! add_field {
         }
     };
 
-    // Create a setter that inserts into a map
+    // Create a setter that inserts into a map.
     ($method:ident <- $field:ident: $ty:ty) => {
         pub fn $method(mut self, id: String, data: $ty) -> Mail<'a> {
             self.$field.insert(id, data);

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -52,60 +52,76 @@ impl Mail {
     }
 
     /// Adds a CC recipient to the Mail struct.
-    pub fn add_cc<T: Into<String>>(&mut self, cc_addr: T) {
-        self.cc.push(cc_addr.into())
+    pub fn add_cc<T: Into<String>>(mut self, cc_addr: T) -> Mail {
+        self.cc.push(cc_addr.into());
+        self
     }
 
     /// Adds a to recipient to the Mail struct.
-    pub fn add_to<T: Into<String>>(&mut self, to_addr: T) {
-        self.to.push(to_addr.into())
+    pub fn add_to<T: Into<String>>(mut self, to_addr: T) -> Mail {
+        self.to.push(to_addr.into());
+        self
     }
 
     /// Set the from address for the Mail struct. This can be changed, but there
     /// is only one from address per message.
-    pub fn add_from<T: Into<String>>(&mut self, from_addr: T) {
-        self.from = from_addr.into()
+    pub fn add_from<T: Into<String>>(mut self, from_addr: T) -> Mail {
+        self.from = from_addr.into();
+        self
     }
 
     /// Set the subject of the message.
-    pub fn add_subject<T: Into<String>>(&mut self, subject: T) {
-        self.subject = subject.into()
+    pub fn add_subject<T: Into<String>>(mut self, subject: T) -> Mail {
+        self.subject = subject.into();
+        self
     }
 
     /// This function sets the HTML content for the message.
-    pub fn add_html<T: Into<String>>(&mut self, html: T) {
-        self.html = html.into()
+    pub fn add_html<T: Into<String>>(mut self, html: T) -> Mail {
+        self.html = html.into();
+        self
     }
 
     /// Add a name for the "to" field in the message. The number of to names
     /// must match the number of "to" addresses.
-    pub fn add_to_name<T: Into<String>>(&mut self, to_name: T) {
-        self.to_names.push(to_name.into());
+    pub fn add_to_name<T: Into<String>>(mut self, to_name: T) -> Mail {
+        self.to_names.push(to_name.into());;
+        self
     }
 
     /// Set the text content of the message.
-    pub fn add_text<T: Into<String>>(&mut self, text: T) {
-        self.text = text.into()
+    pub fn add_text<T: Into<String>>(mut self, text: T) -> Mail {
+        self.text = text.into();
+        self
     }
 
     /// Add a BCC address to the message.
-    pub fn add_bcc<T: Into<String>>(&mut self, bcc_addr: T) {
-        self.bcc.push(bcc_addr.into())
+    pub fn add_bcc<T: Into<String>>(mut self, bcc_addr: T) -> Mail {
+        self.bcc.push(bcc_addr.into());
+        self
     }
 
     /// Set the from name for the message.
-    pub fn add_from_name<T: Into<String>>(&mut self, from_name: T) {
-        self.from_name = from_name.into()
+    pub fn add_from_name<T: Into<String>>(mut self, from_name: T) -> Mail {
+        self.from_name = from_name.into();
+        self
     }
 
     /// Set the reply to address for the message.
-    pub fn add_reply_to<T: Into<String>>(&mut self, reply_to: T) {
-        self.reply_to = reply_to.into()
+    pub fn add_reply_to<T: Into<String>>(mut self, reply_to: T) -> Mail {
+        self.reply_to = reply_to.into();
+        self
     }
 
     /// Set the date for the message. This must be a valid RFC 822 timestamp.
-    pub fn add_date(&mut self, date: String) {
-        self.date = date
+    pub fn add_date(mut self, date: String) -> Mail {
+        self.date = date;
+        self
+    }
+
+    /// Convenience method when using Mail as a builder
+    pub fn build(self) -> Mail {
+        self
     }
 
     /// Add an attachment for the message. You can pass the name of a file as a
@@ -114,10 +130,10 @@ impl Mail {
     /// # Examples
     ///
     /// ```ignore
-    /// let mut message = Mail::new();
-    /// message.add_attachment("/path/to/file/contents.txt");
+    /// let message = Mail::new()
+    ///     .add_attachment("/path/to/file/contents.txt");
     /// ```
-    pub fn add_attachment<P: AsRef<Path>>(&mut self, path: P) -> SendgridResult<()> {
+    pub fn add_attachment<P: AsRef<Path>>(mut self, path: P) -> SendgridResult<Mail> {
         let mut file = File::open(&path)?;
         let mut data = String::new();
         file.read_to_string(&mut data)?;
@@ -128,22 +144,24 @@ impl Mail {
             return Err(SendgridErrorKind::InvalidFilename.into());
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Add content for inline images in the message.
-    pub fn add_content(&mut self, id: &str, value: &str) {
+    pub fn add_content(mut self, id: &str, value: &str) -> Mail {
         self.content.insert(id.to_string(), value.to_string());
+        self
     }
 
     /// Add a custom header for the message. These are usually prefixed with
     /// 'X' or 'x' per the RFC specifications.
-    pub fn add_header(&mut self, header: &str, value: &str) {
+    pub fn add_header(mut self, header: &str, value: &str) -> Mail {
         self.headers.insert(header.to_string(), value.to_string());
+        self
     }
 
     /// Used internally for string encoding. Not needed for message building.
-    pub fn make_header_string(&mut self) -> SendgridResult<String> {
+    pub(crate) fn make_header_string(&mut self) -> SendgridResult<String> {
         let string = serde_json::to_string(&self.headers)?;
         Ok(string)
     }
@@ -151,7 +169,8 @@ impl Mail {
     /// Add an X-SMTPAPI string to the message. This can be done by using the
     /// 'rustc_serialize' crate and JSON encoding a map or custom struct. Or
     /// a regular String type can be escaped and used.
-    pub fn add_x_smtpapi(&mut self, x_smtpapi: String) {
-        self.x_smtpapi = x_smtpapi
+    pub fn add_x_smtpapi(mut self, x_smtpapi: String) -> Mail {
+        self.x_smtpapi = x_smtpapi;
+        self
     }
 }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -10,117 +10,117 @@ use serde_json;
 #[derive(Debug)]
 /// This is a representation of a valid SendGrid message. It has support for
 /// all of the fields in the V2 API.
-pub struct Mail {
-    pub to: Vec<String>,
-    pub to_names: Vec<String>,
-    pub cc: Vec<String>,
-    pub bcc: Vec<String>,
-    pub from: String,
-    pub subject: String,
-    pub html: String,
-    pub text: String,
-    pub from_name: String,
-    pub reply_to: String,
-    pub date: String,
+pub struct Mail<'a> {
+    pub to: Vec<&'a str>,
+    pub to_names: Vec<&'a str>,
+    pub cc: Vec<&'a str>,
+    pub bcc: Vec<&'a str>,
+    pub from: &'a str,
+    pub subject: &'a str,
+    pub html: &'a str,
+    pub text: &'a str,
+    pub from_name: &'a str,
+    pub reply_to: &'a str,
+    pub date: &'a str,
     pub attachments: HashMap<String, String>,
-    pub content: HashMap<String, String>,
-    pub headers: HashMap<String, String>,
-    pub x_smtpapi: String,
+    pub content: HashMap<String, &'a str>,
+    pub headers: HashMap<String, &'a str>,
+    pub x_smtpapi: &'a str,
 }
 
-impl Mail {
+impl<'a> Mail<'a> {
     /// Returns a new Mail struct to send with a client. All of the fields are
     /// initially empty.
-    pub fn new() -> Mail {
+    pub fn new() -> Mail<'a> {
         Mail {
             to: Vec::new(),
             to_names: Vec::new(),
             cc: Vec::new(),
             bcc: Vec::new(),
-            from: String::new(),
-            subject: String::new(),
-            html: String::new(),
-            text: String::new(),
-            from_name: String::new(),
-            reply_to: String::new(),
-            date: String::new(),
+            from: "",
+            subject: "",
+            html: "",
+            text: "",
+            from_name: "",
+            reply_to: "",
+            date: "",
             attachments: HashMap::new(),
             content: HashMap::new(),
             headers: HashMap::new(),
-            x_smtpapi: String::new(),
+            x_smtpapi: "",
         }
     }
 
     /// Adds a CC recipient to the Mail struct.
-    pub fn add_cc<T: Into<String>>(mut self, cc_addr: T) -> Mail {
-        self.cc.push(cc_addr.into());
+    pub fn add_cc(mut self, cc_addr: &'a str) -> Mail<'a> {
+        self.cc.push(cc_addr.as_ref());
         self
     }
 
     /// Adds a to recipient to the Mail struct.
-    pub fn add_to<T: Into<String>>(mut self, to_addr: T) -> Mail {
-        self.to.push(to_addr.into());
+    pub fn add_to(mut self, to_addr: &'a str) -> Mail<'a> {
+        self.to.push(to_addr.as_ref());
         self
     }
 
     /// Set the from address for the Mail struct. This can be changed, but there
     /// is only one from address per message.
-    pub fn add_from<T: Into<String>>(mut self, from_addr: T) -> Mail {
-        self.from = from_addr.into();
+    pub fn add_from(mut self, from_addr: &'a str) -> Mail<'a> {
+        self.from = from_addr.as_ref();
         self
     }
 
     /// Set the subject of the message.
-    pub fn add_subject<T: Into<String>>(mut self, subject: T) -> Mail {
-        self.subject = subject.into();
+    pub fn add_subject(mut self, subject: &'a str) -> Mail<'a> {
+        self.subject = subject.as_ref();
         self
     }
 
     /// This function sets the HTML content for the message.
-    pub fn add_html<T: Into<String>>(mut self, html: T) -> Mail {
-        self.html = html.into();
+    pub fn add_html(mut self, html: &'a str) -> Mail<'a> {
+        self.html = html.as_ref();
         self
     }
 
     /// Add a name for the "to" field in the message. The number of to names
     /// must match the number of "to" addresses.
-    pub fn add_to_name<T: Into<String>>(mut self, to_name: T) -> Mail {
-        self.to_names.push(to_name.into());;
+    pub fn add_to_name(mut self, to_name: &'a str) -> Mail<'a> {
+        self.to_names.push(to_name.as_ref());;
         self
     }
 
     /// Set the text content of the message.
-    pub fn add_text<T: Into<String>>(mut self, text: T) -> Mail {
-        self.text = text.into();
+    pub fn add_text(mut self, text: &'a str) -> Mail<'a> {
+        self.text = text.as_ref();
         self
     }
 
     /// Add a BCC address to the message.
-    pub fn add_bcc<T: Into<String>>(mut self, bcc_addr: T) -> Mail {
-        self.bcc.push(bcc_addr.into());
+    pub fn add_bcc(mut self, bcc_addr: &'a str) -> Mail<'a> {
+        self.bcc.push(bcc_addr.as_ref());
         self
     }
 
     /// Set the from name for the message.
-    pub fn add_from_name<T: Into<String>>(mut self, from_name: T) -> Mail {
-        self.from_name = from_name.into();
+    pub fn add_from_name(mut self, from_name: &'a str) -> Mail<'a> {
+        self.from_name = from_name.as_ref();
         self
     }
 
     /// Set the reply to address for the message.
-    pub fn add_reply_to<T: Into<String>>(mut self, reply_to: T) -> Mail {
-        self.reply_to = reply_to.into();
+    pub fn add_reply_to(mut self, reply_to: &'a str) -> Mail<'a> {
+        self.reply_to = reply_to.as_ref();
         self
     }
 
     /// Set the date for the message. This must be a valid RFC 822 timestamp.
-    pub fn add_date(mut self, date: String) -> Mail {
-        self.date = date;
+    pub fn add_date(mut self, date: &'a str) -> Mail<'a> {
+        self.date = date.as_ref();
         self
     }
 
     /// Convenience method when using Mail as a builder
-    pub fn build(self) -> Mail {
+    pub fn build(self) -> Mail<'a> {
         self
     }
 
@@ -133,7 +133,7 @@ impl Mail {
     /// let message = Mail::new()
     ///     .add_attachment("/path/to/file/contents.txt");
     /// ```
-    pub fn add_attachment<P: AsRef<Path>>(mut self, path: P) -> SendgridResult<Mail> {
+    pub fn add_attachment<P: AsRef<Path>>(mut self, path: P) -> SendgridResult<Mail<'a>> {
         let mut file = File::open(&path)?;
         let mut data = String::new();
         file.read_to_string(&mut data)?;
@@ -148,15 +148,15 @@ impl Mail {
     }
 
     /// Add content for inline images in the message.
-    pub fn add_content(mut self, id: &str, value: &str) -> Mail {
-        self.content.insert(id.to_string(), value.to_string());
+    pub fn add_content(mut self, id: String, value: &'a str) -> Mail<'a> {
+        self.content.insert(id, value);
         self
     }
 
     /// Add a custom header for the message. These are usually prefixed with
     /// 'X' or 'x' per the RFC specifications.
-    pub fn add_header(mut self, header: &str, value: &str) -> Mail {
-        self.headers.insert(header.to_string(), value.to_string());
+    pub fn add_header(mut self, header: String, value: &'a str) -> Mail<'a> {
+        self.headers.insert(header, value);
         self
     }
 
@@ -169,7 +169,7 @@ impl Mail {
     /// Add an X-SMTPAPI string to the message. This can be done by using the
     /// 'rustc_serialize' crate and JSON encoding a map or custom struct. Or
     /// a regular String type can be escaped and used.
-    pub fn add_x_smtpapi(mut self, x_smtpapi: String) -> Mail {
+    pub fn add_x_smtpapi(mut self, x_smtpapi: &'a str) -> Mail<'a> {
         self.x_smtpapi = x_smtpapi;
         self
     }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -7,12 +7,43 @@ use std::path::Path;
 
 use serde_json;
 
+macro_rules! add_field {
+    // Create a setter that appends
+    ($method:ident << $field:ident: $ty:ty) => {
+        pub fn $method(mut self, data: $ty) -> Mail<'a> {
+            self.$field.push(data);
+            self
+        }
+    };
+
+    // Create a setter that stores
+    ($method:ident = $field:ident: $ty:ty) => {
+        pub fn $method(mut self, data: $ty) -> Mail<'a> {
+            self.$field = data;
+            self
+        }
+    };
+
+    // Create a setter that inserts into a map
+    ($method:ident <- $field:ident: $ty:ty) => {
+        pub fn $method(mut self, id: String, data: $ty) -> Mail<'a> {
+            self.$field.insert(id, data);
+            self
+        }
+    };
+}
+
+#[derive(Debug)]
+pub struct Destination<'a> {
+    pub address: &'a str,
+    pub name: &'a str,
+}
+
 #[derive(Debug)]
 /// This is a representation of a valid SendGrid message. It has support for
 /// all of the fields in the V2 API.
 pub struct Mail<'a> {
-    pub to: Vec<&'a str>,
-    pub to_names: Vec<&'a str>,
+    pub to: Vec<Destination<'a>>,
     pub cc: Vec<&'a str>,
     pub bcc: Vec<&'a str>,
     pub from: &'a str,
@@ -34,7 +65,6 @@ impl<'a> Mail<'a> {
     pub fn new() -> Mail<'a> {
         Mail {
             to: Vec::new(),
-            to_names: Vec::new(),
             cc: Vec::new(),
             bcc: Vec::new(),
             from: "",
@@ -52,72 +82,36 @@ impl<'a> Mail<'a> {
     }
 
     /// Adds a CC recipient to the Mail struct.
-    pub fn add_cc(mut self, cc_addr: &'a str) -> Mail<'a> {
-        self.cc.push(cc_addr.as_ref());
-        self
-    }
+    add_field!(add_cc << cc: &'a str);
 
     /// Adds a to recipient to the Mail struct.
-    pub fn add_to(mut self, to_addr: &'a str) -> Mail<'a> {
-        self.to.push(to_addr.as_ref());
-        self
-    }
+    add_field!(add_to << to: Destination<'a>);
 
     /// Set the from address for the Mail struct. This can be changed, but there
     /// is only one from address per message.
-    pub fn add_from(mut self, from_addr: &'a str) -> Mail<'a> {
-        self.from = from_addr.as_ref();
-        self
-    }
+    add_field!(add_from = from: &'a str);
 
     /// Set the subject of the message.
-    pub fn add_subject(mut self, subject: &'a str) -> Mail<'a> {
-        self.subject = subject.as_ref();
-        self
-    }
+    add_field!(add_subject = subject: &'a str);
 
     /// This function sets the HTML content for the message.
-    pub fn add_html(mut self, html: &'a str) -> Mail<'a> {
-        self.html = html.as_ref();
-        self
-    }
-
-    /// Add a name for the "to" field in the message. The number of to names
-    /// must match the number of "to" addresses.
-    pub fn add_to_name(mut self, to_name: &'a str) -> Mail<'a> {
-        self.to_names.push(to_name.as_ref());;
-        self
-    }
+    add_field!(add_html = html: &'a str);
 
     /// Set the text content of the message.
-    pub fn add_text(mut self, text: &'a str) -> Mail<'a> {
-        self.text = text.as_ref();
-        self
-    }
+    add_field!(add_text = text: &'a str);
 
     /// Add a BCC address to the message.
-    pub fn add_bcc(mut self, bcc_addr: &'a str) -> Mail<'a> {
-        self.bcc.push(bcc_addr.as_ref());
-        self
-    }
+    add_field!(add_bcc << bcc: &'a str);
 
     /// Set the from name for the message.
-    pub fn add_from_name(mut self, from_name: &'a str) -> Mail<'a> {
-        self.from_name = from_name.as_ref();
-        self
-    }
+    add_field!(add_from_name = from_name: &'a str);
 
     /// Set the reply to address for the message.
-    pub fn add_reply_to(mut self, reply_to: &'a str) -> Mail<'a> {
-        self.reply_to = reply_to.as_ref();
-        self
-    }
+    add_field!(add_reply_to = reply_to: &'a str);
 
     /// Set the date for the message. This must be a valid RFC 822 timestamp.
-    pub fn add_date(mut self, date: &'a str) -> Mail<'a> {
-        self.date = date.as_ref();
-        self
-    }
+    // TODO(richo) Should this be a chronos::Utc ?
+    add_field!(add_date = date: &'a str);
 
     /// Convenience method when using Mail as a builder
     pub fn build(self) -> Mail<'a> {
@@ -148,17 +142,11 @@ impl<'a> Mail<'a> {
     }
 
     /// Add content for inline images in the message.
-    pub fn add_content(mut self, id: String, value: &'a str) -> Mail<'a> {
-        self.content.insert(id, value);
-        self
-    }
+    add_field!(add_content <- content: &'a str);
 
     /// Add a custom header for the message. These are usually prefixed with
     /// 'X' or 'x' per the RFC specifications.
-    pub fn add_header(mut self, header: String, value: &'a str) -> Mail<'a> {
-        self.headers.insert(header, value);
-        self
-    }
+    add_field!(add_header <- headers: &'a str);
 
     /// Used internally for string encoding. Not needed for message building.
     pub(crate) fn make_header_string(&mut self) -> SendgridResult<String> {
@@ -169,8 +157,5 @@ impl<'a> Mail<'a> {
     /// Add an X-SMTPAPI string to the message. This can be done by using the
     /// 'rustc_serialize' crate and JSON encoding a map or custom struct. Or
     /// a regular String type can be escaped and used.
-    pub fn add_x_smtpapi(mut self, x_smtpapi: &'a str) -> Mail<'a> {
-        self.x_smtpapi = x_smtpapi;
-        self
-    }
+    add_field!(add_x_smtpapi = x_smtpapi: &'a str);
 }

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -113,7 +113,7 @@ impl<'a> Mail<'a> {
     // TODO(richo) Should this be a chronos::Utc ?
     add_field!(add_date = date: &'a str);
 
-    /// Convenience method when using Mail as a builder
+    /// Convenience method when using Mail as a builder.
     pub fn build(self) -> Mail<'a> {
         self
     }

--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -102,11 +102,11 @@ impl SGClient {
 
 #[test]
 fn basic_message_body() {
-    let mut m = Mail::new();
-    m.add_to("test@example.com");
-    m.add_from("me@example.com");
-    m.add_subject("Test");
-    m.add_text("It works");
+    let m = Mail::new()
+        .add_to("test@example.com")
+        .add_from("me@example.com")
+        .add_subject("Test")
+        .add_text("It works");
 
     let body = make_post_body(m);
     let want = "to%5B%5D=test%40example.com&from=me%40example.com&subject=Test&\

--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -79,7 +79,7 @@ impl SGClient {
     /// Sends a messages through the SendGrid API. It takes a Mail struct as an
     /// argument. It returns the string response from the API as JSON.
     /// It sets the Content-Type to be application/x-www-form-urlencoded.
-    pub fn send(self, mail_info: Mail) -> SendgridResult<String> {
+    pub fn send(&self, mail_info: Mail) -> SendgridResult<String> {
         let client = Client::new();
         let mut headers = Headers::new();
         headers.set(Authorization(Bearer {

--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -1,6 +1,6 @@
 use errors::SendgridResult;
 
-use mail::{Mail,Destination};
+use mail::{Destination, Mail};
 
 use std::io::Read;
 
@@ -103,8 +103,7 @@ fn basic_message_body() {
         .add_to(Destination {
             address: "test@example.com",
             name: "Testy mcTestFace",
-        })
-        .add_from("me@example.com")
+        }).add_from("me@example.com")
         .add_subject("Test")
         .add_text("It works");
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -266,7 +266,7 @@ impl Personalization {
                     h.insert(name, value);
                 }
                 self.headers = Some(h);
-            },
+            }
             Some(ref mut h) => {
                 h.extend(headers);
             }


### PR DESCRIPTION
Heyo,

Feel free to push back on any/everything in here! I made a bunch of breaking changes, but I think with decent justification.

The switch from String's to &str is fairly important to me. I have an application which can't move ownership of it's metadata around, and copies get expensive pretty quickly.

The builder stuff isn't particularly important at all, but it does let you avoid having to make your Mail objects `mut` which is nice, and this is also a super common pattern in rust. The more common pattern is to have a MailBuilder which doesn't let you have a concrete Mail until you ::build(), I can implement that if you have the appetite but I wanted to get your thoughts on this.

We could also save a ton of copypasting by using a macro to generate these methods (ala https://github.com/richo/archiver/blob/master/src/pushover.rs#L68-L74). Again, I'll happily implement that if you like.