### PR TITLE
Migrate from error chain to failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ readme = "README.md"
 
 [dependencies]
 data-encoding = "2.0"
-error-chain = "0.11"
 reqwest = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1.7"
+failure = "0.1.2"
+failure_derive = "0.1.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,4 +16,22 @@ pub enum SendgridError {
     InvalidFilename,
 }
 
-pub type SendgridResult<T> = Result<T, Error>;
+impl From<reqwest::Error> for SendgridError {
+    fn from(error: reqwest::Error) -> Self {
+        SendgridError::ReqwestError(error)
+    }
+}
+
+impl From<io::Error> for SendgridError {
+    fn from(error: io::Error) -> Self {
+        SendgridError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for SendgridError {
+    fn from(error: serde_json::Error) -> Self {
+        SendgridError::JSONDecode(error)
+    }
+}
+
+pub type SendgridResult<T> = Result<T, SendgridError>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,22 +2,18 @@ use std::io;
 
 use reqwest;
 use serde_json;
+use failure::Error;
 
-error_chain! {
-    types {
-        SendgridError, SendgridErrorKind, SendgridResultExt, SendgridResult;
-    }
-
-    foreign_links {
-        Io(io::Error);
-        JSONDecode(serde_json::Error);
-        ReqwestError(reqwest::Error);
-    }
-
-    errors {
-        InvalidFilename {
-            description("invalid filename")
-            display("could not UTF-8 decode this filename")
-        }
-    }
+#[derive(Fail, Debug)]
+pub enum SendgridError {
+    #[fail(display = "IO Error: {}", _0)]
+    Io(#[cause] io::Error),
+    #[fail(display = "JSON Error: {}", _0)]
+    JSONDecode(#[cause] serde_json::Error),
+    #[fail(display = "HTTP Error: {}", _0)]
+    ReqwestError(#[cause] reqwest::Error),
+    #[fail(display = "could not UTF-8 decode this filename")]
+    InvalidFilename,
 }
+
+pub type SendgridResult<T> = Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate failure_derive;
 
 extern crate data_encoding;
+extern crate failure;
 extern crate reqwest;
 extern crate serde;
 extern crate serde_json;

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -1,4 +1,4 @@
-use errors::{SendgridErrorKind, SendgridResult};
+use errors::{SendgridError, SendgridResult};
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -135,7 +135,7 @@ impl<'a> Mail<'a> {
         if let Some(name) = path.as_ref().to_str() {
             self.attachments.insert(String::from(name), data);
         } else {
-            return Err(SendgridErrorKind::InvalidFilename.into());
+            return Err(SendgridError::InvalidFilename.into());
         }
 
         Ok(self)


### PR DESCRIPTION
Let me know what you think. This obviously breaks some interfaces, I think the only real question is whether you want to return `failure::Errors`. Currently there's basically a roundtrip, since all the errors we wrap implement Fail.

cc #29 