### PR TITLE
add response text for easier debug

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,7 +17,7 @@ pub enum SendgridError {
     #[fail(display = "could not UTF-8 decode this filename")]
     InvalidFilename,
     #[fail(display = "Request failed with StatusCode: {}", _0)]
-    RequestNotSuccessful(reqwest::StatusCode),
+    RequestNotSuccessful(reqwest::StatusCode, String),
 }
 
 impl From<reqwest::Error> for SendgridError {

--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -95,7 +95,10 @@ impl SGClient {
             .send()?;
 
         if !res.status().is_success() {
-            Err(SendgridError::RequestNotSuccessful(res.status()))
+            Err(SendgridError::RequestNotSuccessful(
+                res.status(),
+                res.text()?,
+            ))
         } else {
             Ok(res.text()?)
         }

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -141,8 +141,12 @@ impl Sender {
             .send()
             .await
             .map_err(|err| SendgridError::from(err))?;
+
         if !res.status().is_success() {
-            Err(SendgridError::RequestNotSuccessful(res.status()))
+            Err(SendgridError::RequestNotSuccessful(
+                res.status(),
+                res.text()?,
+            ))
         } else {
             Ok(res)
         }
@@ -155,8 +159,12 @@ impl Sender {
         let headers = self.get_headers()?;
         let body = mail.gen_json();
         let res = client.post(V3_API_URL).headers(headers).body(body).send()?;
+
         if !res.status().is_success() {
-            Err(SendgridError::RequestNotSuccessful(res.status()))
+            Err(SendgridError::RequestNotSuccessful(
+                res.status(),
+                res.text()?,
+            ))
         } else {
             Ok(res)
         }


### PR DESCRIPTION
I tried using this with the new change and it turns out life is really hard when you can't know WHY the status code is not a success, so here is a follow-up PR.