### PR TITLE
fix builder being moved with rustls feature enabled

### DIFF
--- a/src/sg_client.rs
+++ b/src/sg_client.rs
@@ -79,7 +79,7 @@ impl SGClient {
 
         let builder = rq::ClientBuilder::new();
         #[cfg(feature = "rustls")]
-        builder.use_rustls_tls();
+        let builder = builder.use_rustls_tls();
         let client = builder.build().unwrap();
 
         SGClient {


### PR DESCRIPTION
The [`ClientBuilder::use_rustls_tls`](https://docs.rs/reqwest/0.10.7/reqwest/struct.ClientBuilder.html#method.use_rustls_tls) method takes ownership of the builder, so we need to re-assign it. The current 0.12.0 version doesn't compile with a use-after-move error when the `rustls` feature is enabled.
