### PR TITLE
Add ip_pool_name and categories to Message

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -254,6 +254,14 @@ impl Message {
         self
     }
 
+    /// Add multiple categories
+    pub fn add_categories(mut self, categories: Vec<String>) -> Message {
+        self.categories
+            .get_or_insert_with(Vec::new)
+            .extend(categories.iter().cloned());
+        self
+    }
+
     /// Add content to the message.
     pub fn add_content(mut self, c: Content) -> Message {
         self.content.get_or_insert_with(Vec::new).push(c);

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -36,6 +36,12 @@ pub struct Message {
     personalizations: Vec<Personalization>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    categories: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ip_pool_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     reply_to: Option<Email>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,6 +211,8 @@ impl Message {
             content: None,
             attachments: None,
             template_id: None,
+            categories: None,
+            ip_pool_name: None,
         }
     }
 
@@ -229,6 +237,20 @@ impl Message {
     /// Set the template id.
     pub fn set_template_id(mut self, template_id: &str) -> Message {
         self.template_id = Some(String::from(template_id));
+        self
+    }
+
+    /// Set the ip pool name.
+    pub fn set_ip_pool_name(mut self, ip_pool_name: &str) -> Message {
+        self.ip_pool_name = Some(String::from(ip_pool_name));
+        self
+    }
+
+    /// Add a category
+    pub fn add_category(mut self, category: &str) -> Message {
+        self.categories
+            .get_or_insert_with(Vec::new)
+            .push(String::from(category));
         self
     }
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -470,6 +470,52 @@ mod tests {
     }
 
     #[test]
+    fn ip_pool_name() {
+        let json_str = Message::new(Email::new("from_email@test.com"))
+            .add_personalization(Personalization::new(Email::new("to_email@test.com")))
+            .set_ip_pool_name("test_ip_pool")
+            .gen_json();
+        let expected = r#"{"from":{"email":"from_email@test.com"},"subject":"","personalizations":[{"to":[{"email":"to_email@test.com"}]}],"ip_pool_name":"test_ip_pool"}"#;
+        assert_eq!(json_str, expected);
+    }
+
+    #[test]
+    fn single_category() {
+        let json_str = Message::new(Email::new("from_email@test.com"))
+            .add_personalization(Personalization::new(Email::new("to_email@test.com")))
+            .add_category("test_category")
+            .gen_json();
+        let expected = r#"{"from":{"email":"from_email@test.com"},"subject":"","personalizations":[{"to":[{"email":"to_email@test.com"}]}],"categories":["test_category"]}"#;
+        assert_eq!(json_str, expected);
+    }
+
+    #[test]
+    fn multiple_categories() {
+        let json_str_add_vec = Message::new(Email::new("from_email@test.com"))
+            .add_personalization(Personalization::new(Email::new("to_email@test.com")))
+            .add_categories(vec![
+                String::from("test_category1"),
+                String::from("test_category2"),
+            ])
+            .gen_json();
+        let json_str_multiple_adds = Message::new(Email::new("from_email@test.com"))
+            .add_personalization(Personalization::new(Email::new("to_email@test.com")))
+            .add_category("test_category1")
+            .add_category("test_category2")
+            .gen_json();
+        let json_str_vec_and_single = Message::new(Email::new("from_email@test.com"))
+            .add_personalization(Personalization::new(Email::new("to_email@test.com")))
+            .add_category("test_category1")
+            .add_categories(vec![String::from("test_category2")])
+            .gen_json();
+
+        let expected = r#"{"from":{"email":"from_email@test.com"},"subject":"","personalizations":[{"to":[{"email":"to_email@test.com"}]}],"categories":["test_category1","test_category2"]}"#;
+        assert_eq!(json_str_add_vec, expected);
+        assert_eq!(json_str_multiple_adds, expected);
+        assert_eq!(json_str_vec_and_single, expected);
+    }
+
+    #[test]
     fn dynamic_template_data_sgmap() {
         let json_str = Message::new(Email::new("from_email@test.com"))
             .add_personalization(


### PR DESCRIPTION
This is a small PR to expose additional SendGrid API options. I added a few tests that validate the additions are serialized correctly.

Please let me know if there are any additional changes needed.

Cheers,
Alex