### PR TITLE
Add a function to allow attaching custom_args to a Personalization

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -378,6 +378,19 @@ impl Personalization {
         self
     }
 
+    /// Add a custom_args field.
+    pub fn add_custom_args(mut self, custom_args: SGMap) -> Personalization {
+        match self.custom_args {
+            None => {
+                self.custom_args = Some(custom_args);
+            }
+            Some(ref mut h) => {
+                h.extend(custom_args);
+            }
+        }
+        self
+    }
+
     /// Add a dynamic template data field.
     pub fn add_dynamic_template_data(mut self, dynamic_template_data: SGMap) -> Personalization {
         // We can safely unwrap & unreachable here since SGMap will always serialize


### PR DESCRIPTION
We needed the ability to set the custom_args field in Personalization and the crate currently lacks the ability to do so. This PR adds a function to set the custom_args.