### PR TITLE
Adds support for ASM

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,10 @@ pub enum SendgridError {
     #[error("dynamic template data must be a serializable object")]
     InvalidTemplateValue,
 
+    /// A failure that indicates that the number of items exceeded the max allowed items.
+    #[error("the number of items exceeded the max capacity")]
+    TooManyItems,
+
     /// SendGrid returned an unsuccessful HTTP status code.
     #[error("Request failed: `{0}`")]
     RequestNotSuccessful(#[from] RequestNotSuccessful),


### PR DESCRIPTION
Adds support for the ASM object which allows you to specify how to handle unsubscribes.

https://docs.sendgrid.com/api-reference/mail-send/mail-send