### PR TITLE
Allow setting the the host endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ static API_URL: &str = "https://api.sendgrid.com/api/mail.send.json?";
 #[derive(Clone, Debug)]
 pub struct SGClient {
     api_key: String,
-    host: Option<String>,
+    host: String,
     #[cfg(feature = "async")]
     client: reqwest::Client,
     #[cfg(not(feature = "async"))]
@@ -94,14 +94,14 @@ impl SGClient {
         SGClient {
             api_key: key.into(),
             client,
-            host: None,
+            host: API_URL.to_string(),
         }
     }
 
     /// Sets the host to use for the API. This is useful if you are using a proxy or a local
     /// development server. It should be a full URL, including the protocol.
     pub fn set_host<S: Into<String>>(&mut self, host: S) {
-        self.host = Some(host.into());
+        self.host = host.into();
     }
 
     /// Sends a messages through the SendGrid API. It takes a Mail struct as an argument. It returns
@@ -131,7 +131,7 @@ impl SGClient {
         let post_body = make_post_body(mail_info)?;
         let resp = self
             .client
-            .post(self.host.as_ref().map(|s| s.as_str()).unwrap_or(API_URL))
+            .post(&self.host)
             .headers(self.headers()?)
             .body(post_body)
             .send()?;
@@ -172,7 +172,7 @@ impl SGClient {
         let post_body = make_post_body(mail_info)?;
         let resp = self
             .client
-            .post(self.host.as_ref().map(|s| s.as_str()).unwrap_or(API_URL))
+            .post(&self.host)
             .headers(self.headers()?)
             .body(post_body)
             .send()


### PR DESCRIPTION
This allows easier testing for consumers of this library. The endpoint
can be set to be a local server to verify the email is sent correctly.