### PR TITLE
Implement Personalization::new_many

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.devcontainer
+.idea
+
 # Compiled files
 *.o
 *.so

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -449,6 +449,21 @@ impl Personalization {
         }
     }
 
+    /// Construct a new personalization block for this message with a Vec of Email
+    pub fn new_many(email: Vec<Email>) -> Personalization {
+        Personalization {
+            to: email,
+            cc: None,
+            bcc: None,
+            subject: None,
+            headers: None,
+            substitutions: None,
+            custom_args: None,
+            dynamic_template_data: None,
+            send_at: None,
+        }
+    }
+
     /// Add a to field.
     pub fn add_to(mut self, to: Email) -> Personalization {
         self.to.push(to);


### PR DESCRIPTION
Adds Personalization::new_many to accept Vec<Email> for initializing a personalization to multiple email addresses without the requirement of a seed email address. 

Addresses #79 - it appears that #80 solves the same issue by deriving Default but was not merged in.