### PR TITLE
Enable rustls for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 data-encoding = "2.10"
-reqwest = { version = "0.13", default-features = false, features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 data-encoding = "2.10"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
@@ -23,6 +23,7 @@ url = "2.5"
 tokio = { version = "1", features = ["full"] }
 
 [features]
+default = ["reqwest/rustls"]
 blocking = ["reqwest/blocking"]
 native-tls = ["reqwest/native-tls"]
 


### PR DESCRIPTION
## Summary
- enable the `reqwest` `rustls` feature so HTTPS requests work when `default-features = false`

## Motivation
In downstream usage, SendGrid API calls failed with `invalid URL, scheme is not http` when HTTPS was used. Enabling `rustls` provides TLS support without relying on default features.

## Testing
- not run (dependency feature change only)
